### PR TITLE
Feat : Alert, Confirm 모달 컴포넌트 생성

### DIFF
--- a/src/components/Modal/Alert/index.tsx
+++ b/src/components/Modal/Alert/index.tsx
@@ -1,0 +1,39 @@
+import * as S from '../styles';
+import { ModalCSSProps } from '../model';
+
+interface AlertModalProps extends ModalCSSProps {
+  title: string;
+  message: string; // 텍스트만 있는 경우 message
+  children?: React.ReactNode; // 텍스트 외에 다른 컴포넌트가 있는 경우 children
+  confirmText?: string; // 확인 버튼 텍스트
+  onConfirm: () => void; // 확인 버튼 클릭 시 실행할 함수
+}
+
+const AlertModal = ({
+  title,
+  message,
+  children,
+  confirmType = 'confirm',
+  confirmText = '확인',
+  alignType = 'center',
+  onConfirm,
+}: AlertModalProps) => {
+  return (
+    <S.ModalOverlay>
+      <S.ModalContainer alignType={alignType}>
+        <S.ModalHeader>{title}</S.ModalHeader>
+        <S.ModalContent>
+          {message}
+          {children}
+        </S.ModalContent>
+        <S.ButtonContainer>
+          <S.ConfirmButton onClick={onConfirm} confirmType={confirmType}>
+            {confirmText}
+          </S.ConfirmButton>
+        </S.ButtonContainer>
+      </S.ModalContainer>
+    </S.ModalOverlay>
+  );
+};
+
+export default AlertModal;

--- a/src/components/Modal/Confirm/index.tsx
+++ b/src/components/Modal/Confirm/index.tsx
@@ -1,0 +1,44 @@
+import * as S from '../styles';
+import { ModalCSSProps } from '../model';
+
+interface AlertModalProps extends ModalCSSProps {
+  title: string;
+  message: string; // 텍스트만 있는 경우 message
+  confirmText?: string; // 확인 버튼 텍스트
+  cancelText?: string; // 취소 버튼 텍스트
+  children?: React.ReactNode; // 텍스트 외에 다른 컴포넌트가 있는 경우 children
+  onConfirm: () => void; // 확인 버튼 클릭 시 실행할 함수
+  onCancel: () => void; // 취소 버튼 클릭 시 실행할 함수
+}
+
+const ConfirmModal = ({
+  title,
+  message,
+  children,
+  confirmType = 'confirm',
+  confirmText = '확인',
+  cancelText = '취소',
+  alignType = 'center',
+  onCancel,
+  onConfirm,
+}: AlertModalProps) => {
+  return (
+    <S.ModalOverlay>
+      <S.ModalContainer alignType={alignType}>
+        <S.ModalHeader>{title}</S.ModalHeader>
+        <S.ModalContent>
+          {message}
+          {children}
+        </S.ModalContent>
+        <S.ButtonContainer>
+          <S.CancelButton onClick={onCancel}>{cancelText}</S.CancelButton>
+          <S.ConfirmButton onClick={onConfirm} confirmType={confirmType}>
+            {confirmText}
+          </S.ConfirmButton>
+        </S.ButtonContainer>
+      </S.ModalContainer>
+    </S.ModalOverlay>
+  );
+};
+
+export default ConfirmModal;

--- a/src/components/Modal/model.ts
+++ b/src/components/Modal/model.ts
@@ -1,0 +1,4 @@
+export interface ModalCSSProps {
+  alignType?: 'center' | 'top'; // 모달 위치, default: center
+  confirmType?: 'confirm' | 'warning'; // 모달 버튼 색상, default: confirm
+}

--- a/src/components/Modal/styles.ts
+++ b/src/components/Modal/styles.ts
@@ -1,0 +1,99 @@
+import styled, { css } from 'styled-components';
+import { ModalCSSProps } from './model';
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+export const ModalContainer = styled.div<ModalCSSProps>`
+  position: fixed;
+  z-index: 10000;
+  width: 100%;
+  max-width: 500px;
+  background-color: white;
+  border-radius: 10px;
+  padding: 30px 24px;
+  box-sizing: border-box;
+
+  ${(props) => {
+    switch (props.alignType) {
+      case 'center':
+        return `
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+      `;
+      case 'top':
+        return `
+            top: 180px;
+            left: 50%;
+            transform: translateX(-50%);
+        `;
+      default:
+        return `
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+        `;
+    }
+  }}
+`;
+
+export const ModalHeader = styled.h2`
+  margin-bottom: 14px;
+`;
+
+export const ModalContent = styled.div``;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 20px;
+`;
+
+export const ConfirmButton = styled.button<ModalCSSProps>`
+  width: fit-content;
+  min-width: 80px;
+  margin-left: 10px;
+  padding: 10px;
+  border-radius: 5px;
+
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+
+  ${(props) => {
+    switch (props.confirmType) {
+      case 'confirm':
+        return css`
+          background-color: ${(props) => props.theme.color.primary};
+        `;
+      case 'warning':
+        return css`
+          background-color: ${(props) => props.theme.color.red};
+          color: #fff;
+        `;
+      default:
+        return css`
+          background-color: ${(props) => props.theme.color.primary};
+        `;
+    }
+  }}
+`;
+
+export const CancelButton = styled.button`
+  width: fit-content;
+  min-width: 80px;
+  padding: 10px;
+  border-radius: 5px;
+  background-color: #f0f0f0;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+`;


### PR DESCRIPTION
## 😀 개요
- Alert, Confirm 컴포넌트 생성

## 🛠️ 작업사항
- Alert (확인 버튼) 컴포넌트 생성
- Confirm (확인 취소 버튼) 컴포넌트 생성 

## 🤔 사용방법
- title : 모달 컴포넌트 이름
- message : 컴포넌트 설명, 메세지만 있을 때 message로만 props를 내린다.
- children?: 이미지 등 별개 컴포넌트 있는 경우 children
- alignType? : 기본은 center, optional : top 
- confirmType?: 기본은 confirm, 다만 사용자에게 경고를 줄 필요가 있을 때 optional warning (붉은 색 버튼으로 바뀜)
- onConfirm : 확인 버튼 눌렀을 때 이벤트 트리거
- onCancel: 취소 버튼 눌렀을 때 이벤트 트리거
- confirmText? : 확인 버튼 텍스트, 기본은 '확인'
- cancelText?: 취소 버튼 텍스트, 기본은 '취소' 