### PR TITLE
Chore: webpack hash 설정 변경

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
   entry: './src/index.tsx',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: '[name].[contenthash:8].js',
+    filename: '[name].[chunkhash:8].js',
   },
   devServer: {
     port: 3000,
@@ -72,8 +72,8 @@ module.exports = {
     }),
     new MiniCssExtractPlugin({
       linkType: false,
-      filename: '[name].[contenthash].css',
-      chunkFilename: '[id].[contenthash].css',
+      filename: '[name].[chunkhash].css',
+      chunkFilename: '[id].[chunkhash].css',
     }),
     new Dotenv(),
   ],


### PR DESCRIPTION
## 😀 개요

- js heap out of memory 발생

## 🛠️ 작업사항

- contenthash -> chunkhash